### PR TITLE
Add padding

### DIFF
--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -478,6 +478,11 @@ section {
   }
 }
 
+// FIX FOR LIST GROUPS WHERE BOOTSTRAPS SETTINGS OVERWRITE THE GRIDS PADDING
+.list-group {
+  padding-left: 15px;
+}
+
 .rating {
   display: block;
   float: none !important;


### PR DESCRIPTION
for list-group classes to realign them with the grid.
![padding](https://cloud.githubusercontent.com/assets/1640079/5988774/e215e5d8-a96e-11e4-946f-eca5835bf85f.png)
(issue)